### PR TITLE
Add LaubwerkDB, Preferences, and dynamic loading

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -55,10 +55,10 @@ plants_path = ""
 sdk_path = ""
 current_path = ""
 plant = None
-locale = "en"
-alt_locale = "en_US"
 
-# TODO get the locale from the current blender installation via bpy.app.translations.locale. This can be void.
+# TODO get the locale from the current blender installation via bpy.app.translations.locale.
+locale = "en_US"
+alt_locale = "en"
 
 
 # Update Database Operator (called from AddonPreferences)
@@ -188,14 +188,14 @@ class ImportLBW(bpy.types.Operator, ImportHelper):
         items = []
         for model in plant["models"].keys():
             index = plant["models"][model]["index"]
-            items.append((model, db.get_label(model), "", index))
+            items.append((model, db.get_label(model, locale, alt_locale), "", index))
         return items
 
     def model_season_callback(self, context):
         global locale, alt_locale, db, plant
         items = []
         for qualifier in plant["models"][self.model_id]["qualifiers"]:
-            items.append((qualifier, db.get_label(qualifier), ""))
+            items.append((qualifier, db.get_label(qualifier, locale, alt_locale), ""))
         return items
 
     model_id: EnumProperty(items=model_id_callback, name="Model")
@@ -242,7 +242,7 @@ class ImportLBW(bpy.types.Operator, ImportHelper):
             self.model_season = plant["models"][self.model_id]["default_qualifier"]
 
         # Create the UI entries.
-        layout.label(text="%s" % db.get_label(plant["name"]))
+        layout.label(text="%s" % db.get_label(plant["name"], locale, alt_locale))
         layout.label(text="(%s)" % plant["name"])
         layout.prop(self, "model_id")
         layout.prop(self, "model_season")

--- a/__init__.py
+++ b/__init__.py
@@ -184,7 +184,8 @@ class ImportLBW(bpy.types.Operator, ImportHelper):
         global locale, alt_locale, db, plant
         items = []
         for model in plant["models"].keys():
-            items.append((model, db.get_label(model), ""))
+            index = plant["models"][model]["index"]
+            items.append((model, db.get_label(model), "", index))
         return items
 
     def model_season_callback(self, context):

--- a/__init__.py
+++ b/__init__.py
@@ -35,12 +35,12 @@ from bpy.props import (BoolProperty,
 from bpy_extras.io_utils import ImportHelper
 
 bl_info = {
-    "name": "Laubwerk lbw.gz format importer",
-    "author": "Fabian Quosdorf",
-    "version": (0, 1, 0),
+    "name": "Laubwerk Plants Importer",
+    "author": "Darren Hart",
+    "version": (0, 1, 9),
     "blender": (2, 80, 0),
     "location": "File > Import",
-    "description": "Import LBW.GZ, Import Laubwerk mesh, UV's, materials and textures",
+    "description": "Import Laubwerk Plant files (lbw.gz)",
     "warning": "",
     'wiki_url': 'https://github.com/dvhart/lbwbl/blob/master/README.md',
     'tracker_url': 'https://github.com/dvhart/lbwbl/issues',

--- a/__init__.py
+++ b/__init__.py
@@ -70,14 +70,14 @@ class LBWBL_OT_rebuild_db(Operator):
 
     def rebuild_db(self, context):
         global db, db_path, plants_path
-        print("Rebuilding Laubwerk database, this may take several minutes...")
+        print("%s: Rebuilding Laubwerk database, this may take several minutes..." % __name__)
         print("  Plants Library: %s" % plants_path)
         print("  Database: %s" % db_path)
         t0 = time.time()
         lbwdb.lbwdb_write(db_path, plants_path, bpy.app.binary_path_python)  # noqa: F821
         db = lbwdb.LaubwerkDB(db_path, bpy.app.binary_path_python)  # noqa: F821
-        self.report({'INFO'}, "Updated Laubwerk database with %d plants in %0.2fs" %
-                    (db.plant_count(), time.time()-t0))
+        self.report({'INFO'}, "%s: Updated Laubwerk database with %d plants in %0.2fs" %
+                    (__name__, db.plant_count(), time.time()-t0))
 
     def invoke(self, context, event):
         return context.window_manager.invoke_confirm(self, event)
@@ -99,11 +99,12 @@ class LBWBL_OT_import_plant_db(Operator):
 
     def import_plant_db(self):
         global db
-        print("Importing Laubwerk Plant into database from %s..." % self.filepath)
+        print("%s: Importing Laubwerk Plant into database from %s" % (__name__, self.filepath))
         t0 = time.time()
         db.import_plant(self.filepath)
         db.save()
-        self.report({'INFO'}, "Imported Laubwerk Plant into database in %0.2fs" % (time.time()-t0))
+        self.report({'INFO'}, "%s: Imported Laubwerk Plant into database in %0.2fs" %
+                    (__name__, time.time()-t0))
 
     def invoke(self, context, event):
         return context.window_manager.invoke_confirm(self, event)

--- a/__init__.py
+++ b/__init__.py
@@ -62,6 +62,7 @@ alt_locale = "en_US"
 
 # TODO get the locale from the current blender installation via bpy.app.translations.locale. This can be void.
 
+
 # Update Database Operator (called from AddonPreferences)
 class LBWBL_OT_update_db(Operator):
     bl_idname = "lbwbl.update_db"
@@ -73,7 +74,6 @@ class LBWBL_OT_update_db(Operator):
 
     def update_db(self, context):
         global db
-        addon_name = __name__.split('.')[0]
         print("Updating Laubwerk database from %s, this may take several minutes..." % self.plants_path)
         t0 = time.time()
         lbwdb.lbwdb_write("lbwdb.json", self.plants_path, bpy.app.binary_path_python)
@@ -88,6 +88,7 @@ class LBWBL_OT_update_db(Operator):
         self.update_db(context)
         context.area.tag_redraw()
         return {'FINISHED'}
+
 
 # Import Plant Operator (called from Import File Dialog)
 class LBWBL_OT_import_plant_db(Operator):
@@ -113,6 +114,7 @@ class LBWBL_OT_import_plant_db(Operator):
         self.import_plant_db()
         context.area.tag_redraw()
         return {'FINISHED'}
+
 
 # Addon Preferences
 class LBWBL_Pref(AddonPreferences):

--- a/__init__.py
+++ b/__init__.py
@@ -18,7 +18,6 @@
 
 # <pep8-80 compliant>
 
-import json
 import os.path
 import time
 
@@ -136,18 +135,19 @@ class ImportLBW(bpy.types.Operator, ImportHelper):
     filter_glob: StringProperty(default="*.lbw;*.lbw.gz", options={'HIDDEN'})
     filepath: StringProperty(name="File Path", maxlen=1024, default="")
 
-    viewport_proxy: BoolProperty(name="Viewport Proxy", default=True)
-    lod_cull_thick: BoolProperty(name="Cull by Thickness", default=False)
-    lod_min_thick: FloatProperty(name="Min. Thickness", default=0.1, min=0.1, max=10000.0, step=1.0)
-    lod_cull_level: BoolProperty(name="Cull by Level", default=False)
-    lod_max_level: IntProperty(name="Maximum Level", default=5, min=0, max=10, step=1)
+    # Viewport Settings
+    viewport_proxy: BoolProperty(name="Display Proxy", default=True)
+
+    # Render Settings
     lod_subdiv: IntProperty(name="Subdivision", default=3, min=0, max=5, step=1)
-    leaf_amount: FloatProperty(name="Leaf amount",
-                               description="The amount of leafs of the plant.",
-                               default=100.0, min=0.01, max=100.0, subtype='PERCENTAGE')
     leaf_density: FloatProperty(name="Leaf density",
                                 description="The density of the leafs of the plant.",
                                 default=100.0, min=0.01, max=100.0, subtype='PERCENTAGE')
+    leaf_amount: FloatProperty(name="Leaf amount",
+                               description="The amount of leafs of the plant.",
+                               default=100.0, min=0.01, max=100.0, subtype='PERCENTAGE')
+    lod_max_level: IntProperty(name="Maximum Level", default=5, min=0, max=10, step=1)
+    lod_min_thick: FloatProperty(name="Minimum Thickness", default=0.1, min=0.1, max=10000.0, step=1.0)
 
     def update_seasons(self, context):
         global locale, alt_locale, s_items, plant, db
@@ -208,13 +208,6 @@ class ImportLBW(bpy.types.Operator, ImportHelper):
             layout.label(text="Addon Preferences.")
             return
 
-        # reset property defaults
-        # TODO: do we need to do this?
-        #props = context.object.bl_rna.properties
-        #for prop in ["leaf_density", "viewport_proxy", "lod_cull_thick", "lod_min_thick",
-        #             "lod_cull_level", "lod_max_level", "leaf_amount", "lod_subdiv"]:
-        #    self.__setattr__(prop, props[prop].default)
-
         # Create the UI entries.
         layout.label(text="%s" % db.get_label(plant["name"]))
         layout.label(text="(%s)" % plant["name"])
@@ -223,72 +216,15 @@ class ImportLBW(bpy.types.Operator, ImportHelper):
 
         box = layout.box()
         box.label(text="Viewport Settings")
-        box.prop(self, "viewport_proxy", text="Display Proxy")
+        box.prop(self, "viewport_proxy")
 
-        box2 = layout.box()
-        box2.label(text="Render Settings")
-        box2.prop(self, "lod_subdiv")
-        box2.prop(self, "leaf_density")
-        box2.prop(self, "leaf_amount")
-
-        box = box2.box()
-        box.prop(self, "lod_cull_thick")
-        subrow = box.row()
-        subrow.active = self.lod_cull_thick
-        subrow.prop(self, "lod_min_thick")
-        box = box2.box()
-        box.prop(self, "lod_cull_level")
-        subrow = box.row()
-        subrow.active = self.lod_cull_level
-        subrow.prop(self, "lod_max_level")
-
-
-class lbwPanel(bpy.types.Panel):  # panel to display laubwerk plant specific properties.
-    bl_space_type = "PROPERTIES"  # show up in: properties view
-    bl_region_type = "WINDOW"     # show up in: object context
-    bl_label = "Laubwerk Plant"   # name of the new panel
-    bl_context = "object"
-    bl_rna = None  # FIXME: why do I need this? dvhart
-    tr = None
-
-    @classmethod
-    def poll(self, context):
-        global plant, current_path, db
-        if context.object and "lbw_path" in context.object:
-            if not context.object["lbw_path"] == current_path:
-                current_path = context.object["lbw_path"]
-                plant = db.get_plant(current_path)
-                self.object = context.object
-            return True
-
-    def draw(self, context):
-        # display value of Laubwerk plant, of the active object
-        global plant, locale, alt_locale, current_path
-        layout = self.layout
-
-        if plant:
-            pname = plant["name"]
-            layout.label("%s(%s)" % (pname, pname))
-            row = layout.row()
-            box = row.box()
-            box.label("Display settings")
-            box.prop(context.object, "viewport_proxy")
-            row = layout.row()
-            box2 = row.box()
-            box2.label("Level of Detail")
-            box2.prop(context.object, "leaf_density")
-            box = box2.box()
-            box.prop(context.object, "lod_cull_thick")
-            subrow = box.row()
-            subrow.active = context.object.lod_cull_thick
-            subrow.prop(context.object, "lod_min_thick")
-            box = box2.box()
-            box.prop(context.object, "lod_cull_level")
-            subrow = box.row()
-            subrow.active = context.object.lod_cull_level
-            subrow.prop(context.object, "lod_max_level")
-            box2.prop(context.object, "lod_subdiv")
-            box2.prop(context.object, "leaf_amount")
+        box = layout.box()
+        box.label(text="Render Settings")
+        box.prop(self, "lod_subdiv")
+        box.prop(self, "leaf_density")
+        box.prop(self, "leaf_amount")
+        box.prop(self, "lod_max_level")
+        box.prop(self, "lod_min_thick")
 
 
 def menu_func_import(self, context):

--- a/import_lbw.py
+++ b/import_lbw.py
@@ -68,6 +68,12 @@ def lbw_to_bl_obj(plant, name, mesh_lbw, model_season, proxy):
         i += 1
     obj = bpy.data.objects.new(name, mesh)
 
+    # String operations are expensive, do them here outside the material loop
+    wood_mat_name = plant.name + " wood"
+    wood_color = plant.getWoodColor()
+    foliage_mat_name = plant.name + " foliage"
+    foliage_color = plant.getFoliageColor()
+
     # read matids and materialnames and create and add materials to the laubwerktree
     i = 0
     for matID in zip(mesh_lbw.matids):
@@ -76,9 +82,13 @@ def lbw_to_bl_obj(plant, name, mesh_lbw, model_season, proxy):
         mat_name = plantmat.name
         proxy_color = None
 
-        if (proxy):
-            mat_name = "%s %s" % (plant.name, "foliage" if mat_id == -1 else "wood")
-            proxy_color = plant.getFoliageColor() if mat_id == -1 else plant.getWoodColor()
+        if proxy:
+            if mat_id == -1:
+                mat_name = foliage_mat_name
+                proxy_color = foliage_color
+            else:
+                mat_name = wood_mat_name
+                proxy_color = wood_color
 
         if mat_id not in materials:
             materials.append(mat_id)

--- a/import_lbw.py
+++ b/import_lbw.py
@@ -30,6 +30,7 @@ import time
 import bpy
 import laubwerk
 
+
 def lbw_to_bl_obj(plant, name, mesh_lbw, model_season, proxy):
     """ Generate the Blender Object from the Laubwerk mesh and materials """
 
@@ -134,7 +135,7 @@ def lbw_to_bl_mat(plant, mat_id, mat_name, model_season=None, proxy_color=None):
         return mat
 
     # Diffuse Texture (FIXME: Assumes one sided)
-    #print("Diffuse Texture: %s" % plantmat.getFront().diffuseTexture)
+    # print("Diffuse Texture: %s" % plantmat.getFront().diffuseTexture)
     img_path = plantmat.getFront().diffuseTexture
     node_img = nodes.new(type='ShaderNodeTexImage')
     node_img.location = 0, 2 * NH
@@ -145,7 +146,7 @@ def lbw_to_bl_mat(plant, mat_id, mat_name, model_season=None, proxy_color=None):
     # Blender render engines support using the diffuse map alpha channel. We
     # assume this rather than a separate alpha image.
     alpha_path = plantmat.alphaTexture
-    #print("Alpha Texture: %s" % plantmat.alphaTexture)
+    # print("Alpha Texture: %s" % plantmat.alphaTexture)
     if alpha_path != '':
         # Enable leaf clipping in Eevee
         mat.blend_method = 'CLIP'
@@ -156,11 +157,11 @@ def lbw_to_bl_mat(plant, mat_id, mat_name, model_season=None, proxy_color=None):
             print("WARN: Alpha Texture differs from diffuse image path. Not supported.")
 
     # Subsurface Texture
-    #print("Subsurface Color: " + str(plantmat.subsurfaceColor))
+    # print("Subsurface Color: " + str(plantmat.subsurfaceColor))
     if plantmat.subsurfaceColor:
         node_dif.inputs['Subsurface Color'].default_value = plantmat.subsurfaceColor + (1.0,)
 
-    #print("Subsurface Texture: %s" % plantmat.subsurfaceTexture)
+    # print("Subsurface Texture: %s" % plantmat.subsurfaceTexture)
     sub_path = plantmat.subsurfaceTexture
     if sub_path != '':
         node_sub = nodes.new(type='ShaderNodeTexImage')
@@ -169,7 +170,7 @@ def lbw_to_bl_mat(plant, mat_id, mat_name, model_season=None, proxy_color=None):
 
         # Laubwerk models only support subsurface as a translucency effect,
         # indicated by a subsurfaceDepth of 0.0.
-        #print("Subsurface Depth: %f" % plantmat.subsurfaceDepth)
+        # print("Subsurface Depth: %f" % plantmat.subsurfaceDepth)
         if plantmat.subsurfaceDepth == 0.0:
             node_sub.image.colorspace_settings.is_data = True
             links.new(node_sub.outputs['Color'], node_dif.inputs['Transmission'])
@@ -177,7 +178,7 @@ def lbw_to_bl_mat(plant, mat_id, mat_name, model_season=None, proxy_color=None):
             print("WARN: Subsurface Depth > 0. Not supported.")
 
     # Bump Texture
-    #print("Bump Texture: %s" % plantmat.getFront().bumpTexture)
+    # print("Bump Texture: %s" % plantmat.getFront().bumpTexture)
     bump_path = plantmat.getFront().bumpTexture
     if bump_path != '':
         node_bumpimg = nodes.new(type='ShaderNodeTexImage')
@@ -187,16 +188,16 @@ def lbw_to_bl_mat(plant, mat_id, mat_name, model_season=None, proxy_color=None):
         node_bump = nodes.new(type='ShaderNodeBump')
         node_bump.location = NW, 0
         # TODO: Make the Distance configurable to tune for each render engine
-        #print("Bump Strength: %f" % plantmat.getFront().bumpStrength)
+        # print("Bump Strength: %f" % plantmat.getFront().bumpStrength)
         node_bump.inputs['Strength'].default_value = plantmat.getFront().bumpStrength
         node_bump.inputs['Distance'].default_value = 0.02
         links.new(node_bumpimg.outputs['Color'], node_bump.inputs['Height'])
         links.new(node_bump.outputs['Normal'], node_dif.inputs['Normal'])
 
-    #print("Displacement Texture: %s" % plantmat.displacementTexture)
-    #print("Normal Texture: %s" % plantmat.getFront().normalTexture)
-    #print("Specular Texture: %s" % plantmat.getFront().specularTexture)
-    #print("--------------------")
+    # print("Displacement Texture: %s" % plantmat.displacementTexture)
+    # print("Normal Texture: %s" % plantmat.getFront().normalTexture)
+    # print("Specular Texture: %s" % plantmat.getFront().specularTexture)
+    # print("--------------------")
 
     return mat
 

--- a/import_lbw.py
+++ b/import_lbw.py
@@ -216,7 +216,7 @@ class LBWImportDialog(bpy.types.Operator):
         return context.window_manager.invoke_props_dialog(self)
 
     def load(self, context, filepath, leaf_density, model_type, model_id, model_season, viewport_proxy,
-             lod_cull_thick, lod_min_thick, lod_cull_level, lod_max_level, lod_subdiv, leaf_amount):
+             lod_min_thick, lod_max_level, lod_subdiv, leaf_amount):
         """
         Called by the user interface or another script.
         """
@@ -258,13 +258,11 @@ class LBWImportDialog(bpy.types.Operator):
         obj_viewport["model_type"] = model_type
         obj_viewport["model_season"] = model_season
         obj_viewport["viewport_proxy"] = viewport_proxy
-        obj_viewport["lod_cull_thick"] = lod_cull_thick
-        obj_viewport["lod_min_thick"] = lod_min_thick
-        obj_viewport["lod_cull_level"] = lod_cull_level
-        obj_viewport["lod_max_level"] = lod_max_level
         obj_viewport["lod_subdiv"] = lod_subdiv
         obj_viewport["leaf_density"] = leaf_density
         obj_viewport["leaf_amount"] = leaf_amount
+        obj_viewport["lod_max_level"] = lod_max_level
+        obj_viewport["lod_min_thick"] = lod_min_thick
 
         print("\tfinished importing %s in %.4f sec." % (plant.name, (time.time() - time_main)))
         return {'FINISHED'}

--- a/import_lbw.py
+++ b/import_lbw.py
@@ -102,7 +102,7 @@ def lbw_to_bl_obj(plant, name, mesh_lbw, model_season, proxy):
         if mat_index != -1:
             obj.data.polygons[i].material_index = mat_index
         else:
-            print('WARN: Material %s not found' % mat_name)
+            print('%s: WARN: Material %s not found' % (__name__, mat_name))
 
         i += 1
 
@@ -154,7 +154,8 @@ def lbw_to_bl_mat(plant, mat_id, mat_name, model_season=None, proxy_color=None):
         if alpha_path == img_path:
             links.new(node_img.outputs['Alpha'], node_dif.inputs['Alpha'])
         else:
-            print("WARN: Alpha Texture differs from diffuse image path. Not supported.")
+            # TODO: This affects 'Fagus sylvatica'
+            print("%s: WARN: Alpha Texture differs from diffuse image path. Not supported.", __name__)
 
     # Subsurface Texture
     # print("Subsurface Color: " + str(plantmat.subsurfaceColor))
@@ -175,7 +176,7 @@ def lbw_to_bl_mat(plant, mat_id, mat_name, model_season=None, proxy_color=None):
             node_sub.image.colorspace_settings.is_data = True
             links.new(node_sub.outputs['Color'], node_dif.inputs['Transmission'])
         else:
-            print("WARN: Subsurface Depth > 0. Not supported.")
+            print("%s: WARN: Subsurface Depth > 0. Not supported." % __name__)
 
     # Bump Texture
     # print("Bump Texture: %s" % plantmat.getFront().bumpTexture)
@@ -221,7 +222,7 @@ class LBWImportDialog(bpy.types.Operator):
         """
         Called by the user interface or another script.
         """
-        print('importing laubwerk plant from %r' % (filepath))
+        print('%s: Importing Laubwerk Plant from %r' % (__name__, filepath))
 
         time_main = time.time()
         plant = laubwerk.load(filepath)
@@ -240,7 +241,7 @@ class LBWImportDialog(bpy.types.Operator):
         bpy.context.collection.objects.link(obj_viewport)
         obj_viewport.hide_render = True
         obj_viewport.show_name = True
-        print("\tgenerated low resolution viewport object in %.4f sec." % (time.time() - time_local))
+        print("\tgenerated low resolution viewport object in %.4fs" % (time.time() - time_local))
 
         # Create the render object (high detail)
         time_local = time.time()
@@ -252,7 +253,7 @@ class LBWImportDialog(bpy.types.Operator):
         obj_render.parent = obj_viewport
         obj_render.hide_viewport = True
         obj_render.hide_select = True
-        print("\tgenerated high resolution render object in %.4f sec." % (time.time() - time_local))
+        print("\tgenerated high resolution render object in %.4fs" % (time.time() - time_local))
 
         # set custom properties to show in properties tab
         obj_viewport["lbw_path"] = filepath
@@ -265,16 +266,16 @@ class LBWImportDialog(bpy.types.Operator):
         obj_viewport["lod_max_level"] = lod_max_level
         obj_viewport["lod_min_thick"] = lod_min_thick
 
-        print("\tfinished importing %s in %.4f sec." % (plant.name, (time.time() - time_main)))
+        print("\tfinished importing %s in %.4fs" % (plant.name, (time.time() - time_main)))
         return {'FINISHED'}
 
 
 def register():
-    bpy.utils.register_class(LBWImportDialog)   # register dialog
+    bpy.utils.register_class(LBWImportDialog)
 
 
 def unregister():
-    bpy.utils.uregister_class(LBWImportDialog)  # unregister dialog
+    bpy.utils.uregister_class(LBWImportDialog)
 
 
 if __name__ == "__main__":

--- a/import_lbw.py
+++ b/import_lbw.py
@@ -28,7 +28,7 @@ Note, This loads mesh objects and materials.
 """
 import time
 import bpy
-
+import laubwerk
 
 def lbw_to_bl_obj(plant, name, mesh_lbw, model_season, proxy):
     """ Generate the Blender Object from the Laubwerk mesh and materials """
@@ -216,14 +216,14 @@ class LBWImportDialog(bpy.types.Operator):
         return context.window_manager.invoke_props_dialog(self)
 
     def load(self, context, filepath, leaf_density, model_type, model_id, model_season, viewport_proxy,
-             lod_cull_thick, lod_min_thick, lod_cull_level, lod_max_level, lod_subdiv, leaf_amount, plant):
+             lod_cull_thick, lod_min_thick, lod_cull_level, lod_max_level, lod_subdiv, leaf_amount):
         """
         Called by the user interface or another script.
         """
-        print('importing laubwerk plant %s from %r' % (plant.name, filepath))
+        print('importing laubwerk plant from %r' % (filepath))
 
         time_main = time.time()
-
+        plant = laubwerk.load(filepath)
         model = plant.models[model_id]
 
         # Create the viewport object (low detail)

--- a/import_lbw.py
+++ b/import_lbw.py
@@ -216,7 +216,7 @@ class LBWImportDialog(bpy.types.Operator):
     def invoke(self, context, event):
         return context.window_manager.invoke_props_dialog(self)
 
-    def load(self, context, filepath, leaf_density, model_type, model_id, model_season, viewport_proxy,
+    def load(self, context, filepath, leaf_density, model_id, model_season, viewport_proxy,
              lod_min_thick, lod_max_level, lod_subdiv, leaf_amount):
         """
         Called by the user interface or another script.
@@ -256,7 +256,7 @@ class LBWImportDialog(bpy.types.Operator):
 
         # set custom properties to show in properties tab
         obj_viewport["lbw_path"] = filepath
-        obj_viewport["model_type"] = model_type
+        obj_viewport["model_type"] = model.name
         obj_viewport["model_season"] = model_season
         obj_viewport["viewport_proxy"] = viewport_proxy
         obj_viewport["lod_subdiv"] = lod_subdiv

--- a/lbwdb_plant.py
+++ b/lbwdb_plant.py
@@ -1,0 +1,61 @@
+import hashlib
+import json
+import sys
+import laubwerk as lbw
+
+
+def md5sum(filename):
+    md5 = hashlib.md5()
+    with open(filename, mode='rb') as f:
+        buf = f.read(4096)
+        while buf:
+            md5.update(buf)
+            buf = f.read(4096)
+    return md5.hexdigest()
+
+
+def main(filename):
+    p = lbw.load(filename)
+    p_rec = {}
+
+    plant = {}
+    plant["name"] = p.name
+    plant["md5"] = md5sum(filename)
+    plant["default_model"] = p.defaultModel.name
+
+    labels = {}
+    p_labels = {}
+    # Store only the first label per locale
+    for l in p.labels.items():
+        p_labels[l[0]] = l[1][0]
+    labels[p.name] = p_labels
+
+    models = {}
+    for m in p.models:
+        m_rec = {}
+        seasons = []
+        q_labels = {}
+        for q in m.qualifiers:
+            seasons.append(q)
+            q_labels[q] = {}
+            for q_lang in m.qualifierLabels[q].items():
+                q_labels[q][q_lang[0]] = q_lang[1][0]
+        labels.update(q_labels)
+        m_rec["qualifiers"] = seasons
+        m_rec["default_qualifier"] = m.defaultQualifier
+        models[m.name] = m_rec
+        m_labels = {}
+        # FIXME: highly redundant
+        for l in m.labels.items():
+            m_labels[l[0]] = l[1][0]
+        labels[m.name] = m_labels
+    plant["models"] = models
+
+    p_rec["plant"] = plant
+    p_rec["labels"] = labels
+
+    print(json.dumps(p_rec))
+
+
+if __name__ == "__main__":
+    main(sys.argv[1])

--- a/lbwdb_plant.py
+++ b/lbwdb_plant.py
@@ -31,6 +31,7 @@ def main(filename):
     labels[p.name] = p_labels
 
     models = {}
+    i = 0
     for m in p.models:
         m_rec = {}
         seasons = []
@@ -41,6 +42,7 @@ def main(filename):
             for q_lang in m.qualifierLabels[q].items():
                 q_labels[q][q_lang[0]] = q_lang[1][0]
         labels.update(q_labels)
+        m_rec["index"] = i
         m_rec["qualifiers"] = seasons
         m_rec["default_qualifier"] = m.defaultQualifier
         models[m.name] = m_rec
@@ -49,6 +51,7 @@ def main(filename):
         for l in m.labels.items():
             m_labels[l[0]] = l[1][0]
         labels[m.name] = m_labels
+        i = i + 1
     plant["models"] = models
 
     p_rec["plant"] = plant


### PR DESCRIPTION
Introduce a new plant meta-data cache to avoid having to load plant files for names, models, and seasons, speeding up the UI significantly.

Add an Addon Preferences panel to configure the Laubwerk Path, making it possible to dynamically load the laubwerk dependent modules, simplifying the installation and user experience.